### PR TITLE
split code so make root lean

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -24,7 +24,7 @@ import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
 import Root from "./pages/Root";
 import HomePage from "./pages/Home";
-import EventPage from "./pages/Events";
+import EventPage, { loader as eventsLoader } from "./pages/Events";
 import EventDetailPage from "./pages/EventDetail";
 import EventNewPage from "./pages/EventNew";
 import EventEditPage from "./pages/EventEdit";
@@ -40,19 +40,7 @@ const router = createBrowserRouter([
         path: "events",
         element: <RootEvent />,
         children: [
-          {
-            index: true, element: <EventPage />, loader: async () => {
-              const response = await fetch("http://localhost:8080/events");
-
-              if (!response.ok) {
-                // error.
-              } else {
-                // 가져오는 객체는 events라는 프로퍼티를 가지고 있으며 value는 배열이다. 즉, JSON 형식이다.
-                const resData = await response.json();
-                return resData.events;
-              }
-            }
-          },
+          { index: true, element: <EventPage />, loader: eventsLoader },
           { path: ":eventID", element: <EventDetailPage /> },
           { path: "newEvent", element: <EventNewPage /> },
           { path: ":eventID/edit", element: <EventEditPage /> },

--- a/frontend/src/pages/Events.js
+++ b/frontend/src/pages/Events.js
@@ -9,3 +9,15 @@ const EventsPage = () => {
 };
 
 export default EventsPage;
+
+export const loader = async () => {
+  const response = await fetch("http://localhost:8080/events");
+
+  if (!response.ok) {
+    // error.
+  } else {
+    // 가져오는 객체는 events라는 프로퍼티를 가지고 있으며 value는 배열이다. 즉, JSON 형식이다.
+    const resData = await response.json();
+    return resData.events;
+  }
+};


### PR DESCRIPTION
- loader를 router가 정의된 app.js에 작성하면 아무래도 app.js의 코드가 너무 길어진다.
- 따라서 loader 기능이 실질적으로 실행되는 컴포넌트에 loader를 옮겨서 export하고, Router가 정의된 경로에서 import하여 사용한다면 클린코드를 작성할 수 있게 된다. 