### PR TITLE
useRouteLoaderData instead of useLoaderData

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -47,11 +47,17 @@ const router = createBrowserRouter([
           { index: true, element: <EventPage />, loader: eventsLoader },
           {
             path: ":eventID",
-            element: <EventDetailPage />,
+            id: "event-detail",
             loader: eventDetailLoader,
+            children: [
+              {
+                index: true,
+                element: <EventDetailPage />,
+              },
+              { path: "edit", element: <EventEditPage /> },
+            ],
           },
           { path: "newEvent", element: <EventNewPage /> },
-          { path: ":eventID/edit", element: <EventEditPage /> },
         ],
       },
     ],

--- a/frontend/src/components/EventForm.js
+++ b/frontend/src/components/EventForm.js
@@ -1,30 +1,54 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from "react-router-dom";
 
-import classes from './EventForm.module.css';
+import classes from "./EventForm.module.css";
 
 function EventForm({ method, event }) {
   const navigate = useNavigate();
   function cancelHandler() {
-    navigate('..');
+    navigate("..");
   }
 
   return (
     <form className={classes.form}>
       <p>
         <label htmlFor="title">Title</label>
-        <input id="title" type="text" name="title" required />
+        <input
+          id="title"
+          type="text"
+          name="title"
+          required
+          defaultValue={event.title ? event.title : null}
+        />
       </p>
       <p>
         <label htmlFor="image">Image</label>
-        <input id="image" type="url" name="image" required />
+        <input
+          id="image"
+          type="url"
+          name="image"
+          required
+          defaultValue={event.image ? event.image : null}
+        />
       </p>
       <p>
         <label htmlFor="date">Date</label>
-        <input id="date" type="date" name="date" required />
+        <input
+          id="date"
+          type="date"
+          name="date"
+          required
+          defaultValue={event.date ? event.date : null}
+        />
       </p>
       <p>
         <label htmlFor="description">Description</label>
-        <textarea id="description" name="description" rows="5" required />
+        <textarea
+          id="description"
+          name="description"
+          rows="5"
+          required
+          defaultValue={event.description ? event.description : null}
+        />
       </p>
       <div className={classes.actions}>
         <button type="button" onClick={cancelHandler}>

--- a/frontend/src/components/EventItem.js
+++ b/frontend/src/components/EventItem.js
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 import classes from "./EventItem.module.css";
 
 function EventItem({ event }) {
@@ -12,7 +14,7 @@ function EventItem({ event }) {
       <time>{event.date}</time>
       <p>{event.description}</p>
       <menu className={classes.actions}>
-        <a href="edit">Edit</a>
+        <Link to="edit">Edit</Link>
         <button onClick={startDeleteHandler}>Delete</button>
       </menu>
     </article>

--- a/frontend/src/pages/EventDetail.js
+++ b/frontend/src/pages/EventDetail.js
@@ -1,9 +1,9 @@
-import { useLoaderData, json } from "react-router-dom";
+import { useRouteLoaderData, json } from "react-router-dom";
 
 import EventItem from "../components/EventItem";
 
 const EventDetailPage = () => {
-  const loadedData = useLoaderData();
+  const loadedData = useRouteLoaderData("event-detail");
 
   return <EventItem event={loadedData.event} />;
 };

--- a/frontend/src/pages/EventEdit.js
+++ b/frontend/src/pages/EventEdit.js
@@ -1,5 +1,11 @@
+import { useRouteLoaderData } from "react-router-dom";
+
+import EventForm from "../components/EventForm"
+
 const EventEditPage = () => {
-  return <h1> Event Edit Page. </h1>;
+  const loadedData = useRouteLoaderData("event-detail");
+
+  return <EventForm event={loadedData.event} />
 };
 
 export default EventEditPage;


### PR DESCRIPTION
- 하나의 loader가 여러 곳에 쓰여야 한다면 nested Route 구조를 만들어본다.
- loader를 공유하기 위해 부모 Route를 설정하고, 이에 연결되는 Route를 children으로 등록한다.
- 부모 Route에 element가 필수적인 것은 아니다. index 프로퍼티에 의해 해당 컴포넌트가 실행된다.
- HTML 태그의 속성 중 하나인 value대신 JSX에서는 defaultValue를 사용한다.